### PR TITLE
Add eos-after property

### DIFF
--- a/gstchecksumsink.h
+++ b/gstchecksumsink.h
@@ -47,6 +47,7 @@ struct _GstCksumImageSink
   gboolean frame_checksum;
   gboolean plane_checksum;
   gboolean dump_output;
+  gint eos_after;
 
   gchar *raw_file_name;
   gint fd;


### PR DESCRIPTION
Checksumsink will stop rendering/processing frames after
N frames and return GST_FLOW_EOS.

NOTE: some upstream elements (e.g. msdk/vaapi decoders)
may generate a few more calls into checksumsink's render
method as a result of draining/flushing their remaining
queued frames.  However, checksumsink will ignore these
and continue to return GST_FLOW_EOS.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>