### PR TITLE
Add O_BINARY flag for g_open() on Windows

### DIFF
--- a/gstchecksumsink.c
+++ b/gstchecksumsink.c
@@ -262,11 +262,11 @@ open_raw_file (GstCksumImageSink * checksumsink)
   if (checksumsink->fd != -1)
     return TRUE;
   else if (checksumsink->raw_file_name)
-    checksumsink->fd = g_open (checksumsink->raw_file_name, O_WRONLY | O_CREAT,
 #ifndef _WIN32
+    checksumsink->fd = g_open (checksumsink->raw_file_name, O_WRONLY | O_CREAT,
         S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 #else
-        0);
+    checksumsink->fd = g_open (checksumsink->raw_file_name, O_WRONLY | O_CREAT | O_BINARY, 0);
 #endif
   else
     checksumsink->fd =


### PR DESCRIPTION
This flag will make sure the file is open in binary mode. This will avoid some weird pixels being added to yuv.